### PR TITLE
build: enable front-end deploy preview on PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Remember work dir
       run: |
-        pushd
+        pushd -n $(pwd)
     - name: Checkout olympus-frontend
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,5 +25,5 @@ jobs:
         yarn install --frozen-lockfile
         yarn build
       env:
-        # prevent errors from failing the build
+        # prevent errors from failing the build #
         CI: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: OlympusDAO/olympus-frontend
-        path: frontend
     - name: Prepare translations dir
       run: |
         rm -rf src/locales/translations/*

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,3 +24,6 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         yarn install --frozen-lockfile
         yarn build
+      env:
+        # prevent errors from failing the build
+        CI: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,11 +20,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: src/locales/translations
-    - name: Go to work dir
-      run: |
-        cd ${GITHUB_WORKSPACE}
     - name: Build UI for production
       run: |
-        cd /
+        cd ${GITHUB_WORKSPACE}
         yarn install --frozen-lockfile
         yarn build

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,9 @@ jobs:
   build-test-preview:
     runs-on: ubuntu-latest
     steps:
+    - name: Remember work dir
+      run: |
+        pushd
     - name: Checkout olympus-frontend
       uses: actions/checkout@v3
       with:
@@ -20,48 +23,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: src/locales/translations
+    - name: Go to work dir
+      run: |
+        popd
     - name: Build UI for production
       run: |
+        cd /
         yarn install --frozen-lockfile
-        yarn lint
         yarn build
-    - name: Run unit tests
-      run: |
-        yarn test:unit
-
-  #
-  # Does OlympusDAO App use a pre-deploy service?
-  #
-  # If so and it works similar to NETLIFY, then we can run lighthouse test against it on each PR.
-  #
-  # TODO: Update script below to use proper env vars for pre-deploy servce
-  #
-  # lighthouse-deploy-preview:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #  - name: Wait for Netlify preview deployment of this git branch
-  #    if: github.repository_owner == 'ambianic'
-  #    uses: jakepartusch/wait-for-netlify-action@v1
-  #    id: get-netlify-url
-  #    with:
-  #      site_name: "ambianic-pwa-dist"
-  #      max_timeout: 180
-  #  - name: Run Lighthouse PWA check against Netlify PR Preview
-  #    uses: treosh/lighthouse-ci-action@v8
-  #    with:
-  #      urls: |
-  #        ${{ steps.get-netlify-url.outputs.url }}
-  #      uploadArtifacts: true # save results as an action artifacts
-  #      temporaryPublicStorage: true # upload lighthouse report to the temporary storage
-  #      # budgetPath: '.github/lighthouse/budget.json' # performance budgets
-  #      configPath: '.github/lighthouse/lighthouserc-netlify-preview.json' # PWA checks
-  #  - name: Run Lighthouse PWA sanity check against the existing Netlify production deployment
-  #    uses: treosh/lighthouse-ci-action@v8
-  #    with:
-  #      urls: |
-  #        https://ui.ambianic.ai
-  #      uploadArtifacts: true # save results as an action artifacts
-  #      temporaryPublicStorage: true # upload lighthouse report to the temporary storage
-  #      # budgetPath: '.github/lighthouse/budget.json' # performance budgets
-  #      configPath: '.github/lighthouse/lighthouserc-netlify-prod.json' # PWA checks

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,9 +8,6 @@ jobs:
   build-test-preview:
     runs-on: ubuntu-latest
     steps:
-    - name: Remember work dir
-      run: |
-        pushd -n $(pwd)
     - name: Checkout olympus-frontend
       uses: actions/checkout@v3
       with:
@@ -25,7 +22,7 @@ jobs:
         path: src/locales/translations
     - name: Go to work dir
       run: |
-        popd
+        cd ${GITHUB_WORKSPACE}
     - name: Build UI for production
       run: |
         cd /

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,5 +25,5 @@ jobs:
         yarn install --frozen-lockfile
         yarn build
       env:
-        # prevent errors from failing the build #
+        # prevent errors from failing the build
         CI: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,67 @@
+name: Preview Deployment
+
+on:
+  pull_request:
+    branches: [ translators ]
+
+jobs:
+  build-test-preview:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout olympus-frontend
+      uses: actions/checkout@v3
+      with:
+        repository: OlympusDAO/olympus-frontend
+        path: frontend
+    - name: Prepare translations dir
+      run: |
+        rm -rf src/locales/translations/*
+    - name: Checkout translations
+      uses: actions/checkout@v3
+      with:
+        path: src/locales/translations
+    - name: Build UI for production
+      run: |
+        yarn install --frozen-lockfile
+        yarn lint
+        yarn build
+    - name: Run unit tests
+      run: |
+        yarn test:unit
+
+  #
+  # Does OlympusDAO App use a pre-deploy service?
+  #
+  # If so and it works similar to NETLIFY, then we can run lighthouse test against it on each PR.
+  #
+  # TODO: Update script below to use proper env vars for pre-deploy servce
+  #
+  # lighthouse-deploy-preview:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - name: Wait for Netlify preview deployment of this git branch
+  #    if: github.repository_owner == 'ambianic'
+  #    uses: jakepartusch/wait-for-netlify-action@v1
+  #    id: get-netlify-url
+  #    with:
+  #      site_name: "ambianic-pwa-dist"
+  #      max_timeout: 180
+  #  - name: Run Lighthouse PWA check against Netlify PR Preview
+  #    uses: treosh/lighthouse-ci-action@v8
+  #    with:
+  #      urls: |
+  #        ${{ steps.get-netlify-url.outputs.url }}
+  #      uploadArtifacts: true # save results as an action artifacts
+  #      temporaryPublicStorage: true # upload lighthouse report to the temporary storage
+  #      # budgetPath: '.github/lighthouse/budget.json' # performance budgets
+  #      configPath: '.github/lighthouse/lighthouserc-netlify-preview.json' # PWA checks
+  #  - name: Run Lighthouse PWA sanity check against the existing Netlify production deployment
+  #    uses: treosh/lighthouse-ci-action@v8
+  #    with:
+  #      urls: |
+  #        https://ui.ambianic.ai
+  #      uploadArtifacts: true # save results as an action artifacts
+  #      temporaryPublicStorage: true # upload lighthouse report to the temporary storage
+  #      # budgetPath: '.github/lighthouse/budget.json' # performance budgets
+  #      configPath: '.github/lighthouse/lighthouserc-netlify-prod.json' # PWA checks

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,34 @@
+tasks:
+  - name: App
+    init: |
+      # bring in secret access tokens from gitpod user dashboard
+      eval $(gp env -e)
+      # OlmypusDAO front end contributors with access permissions to the main repo
+      # should set GITHUB_OHM_PERSONAL_ACCESS_TOKEN in their gitpod UI Settings panel
+      if [ -z ${GITHUB_OHM_PERSONAL_ACCESS_TOKEN+x} ];
+      then
+        echo "var is unset";
+      else
+        echo "Setting git origin push URL for OlympusDAO/olympus-frontend";
+        git remote set-url --push origin https://${GITHUB_OHM_PERSONAL_ACCESS_TOKEN}@github.com/OlympusDAO/olympus-frontend.git;
+      fi
+      #  create a default .env file if none present
+      if [ ! -f .env ]; then cp ".env.test" ".env"; fi
+      yarn && \
+      gp sync-done install
+  - name: Terminal
+    init: gp sync-await install
+    command: |
+      ls -al
+      pwd
+github:
+  prebuilds:
+    pullRequestsFromForks: true
+    addComment: true
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint
+    - esbenp.prettier-vscode
+    - mhutchie.git-graph
+    - bmuskalla.vscode-tldr
+    - eamodio.gitlens

--- a/olympus-frontend/fr/messages.po
+++ b/olympus-frontend/fr/messages.po
@@ -933,11 +933,11 @@ msgstr "Messire, vous ne possédez pas d'actifs..."
 
 #: src/views/V1-Stake/V1-Stake.jsx:189
 msgid "Single Stake"
-msgstr "Dépôt simple TESTING"
+msgstr "Dépôt simple"
 
 #: src/views/Stake/components/StakeArea/StakeArea.tsx:15
 msgid "Single Stake (3, 3)"
-msgstr "Dépôt simple TESTING (3, 3)"
+msgstr "Dépôt simple (3, 3)"
 
 #: src/views/BondV2/AdvancedSettings.tsx:29
 msgid "Slippage"

--- a/olympus-frontend/fr/messages.po
+++ b/olympus-frontend/fr/messages.po
@@ -933,11 +933,11 @@ msgstr "Messire, vous ne possédez pas d'actifs..."
 
 #: src/views/V1-Stake/V1-Stake.jsx:189
 msgid "Single Stake"
-msgstr "Dépôt simple"
+msgstr "Dépôt simple TESTING"
 
 #: src/views/Stake/components/StakeArea/StakeArea.tsx:15
 msgid "Single Stake (3, 3)"
-msgstr "Dépôt simple (3, 3)"
+msgstr "Dépôt simple TESTING (3, 3)"
 
 #: src/views/BondV2/AdvancedSettings.tsx:29
 msgid "Slippage"

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -1,28 +1,18 @@
 #!/bin/bash
 # enable explicit bash output
 set -x
-pwd
-ls -al
 echo "Checkout front end default(develop) branch"
 git clone https://github.com/OlympusDAO/olympus-frontend frontend
 echo "Remove translations from frontend develop checkout"
 rm -rf frontend/src/locales/translations/*
 echo "Move current branch translations into place for build"
-ls -al olympus-frontend
 cp -rf olympus-frontend frontend/src/locales/translations/
-ls -al frontend/src/locales/translations/
-ls -al frontend/src/locales/translations/olympus-frontend
 # prevent submodule pull
 touch frontend/src/locales/translations/.git
-ls -al frontend/src/locales/translations/
 echo "Switch to frontend work dir"
 cd frontend
-pwd
-ls -al
 echo "Prevent build from failing on warnings"
 export CI=false
 echo "Build OlympusDAP frontent web site "
 yarn install --frozen-lockfile
 yarn build
-pwd
-ls -al

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# enable explicit bash output
+set -x
 pwd
 ls -al
 echo "Checkout front end default(develop) branch"
@@ -6,7 +8,12 @@ git clone https://github.com/OlympusDAO/olympus-frontend frontend
 echo "Remove translations from frontend develop checkout"
 rm -rf frontend/src/locales/translations/*
 echo "Move current branch translations into place for build"
+ls -al olympus-frontend
 cp -rf olympus-frontend frontend/src/locales/translations/
+ls -al frontend/src/locales/translations/
+# prevent submodule pull
+touch frontend/src/locales/translations/.git
+ls -al frontend/src/locales/translations/
 echo "Switch to frontend work dir"
 cd frontend
 pwd

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -11,6 +11,7 @@ echo "Move current branch translations into place for build"
 ls -al olympus-frontend
 cp -rf olympus-frontend frontend/src/locales/translations/
 ls -al frontend/src/locales/translations/
+ls -al frontend/src/locales/translations/olympus-frontend
 # prevent submodule pull
 touch frontend/src/locales/translations/.git
 ls -al frontend/src/locales/translations/
@@ -18,6 +19,8 @@ echo "Switch to frontend work dir"
 cd frontend
 pwd
 ls -al
+echo "Prevent build from failing on warnings"
+export process.env.CI = false
 echo "Build OlympusDAP frontent web site"
 yarn install --frozen-lockfile
 yarn build

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+mkdir frontend
+cd frontend
+git clone https://github.com/OlympusDAO/olympus-frontend
+rm -rf src/locales/translations/*
+mv olympus-frontend src/locales/translations/
+cd frontend
+yarn install --frozen-lockfile
+yarn build

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -6,7 +6,7 @@ git clone https://github.com/OlympusDAO/olympus-frontend frontend
 echo "Remove translations from frontend develop checkout"
 rm -rf frontend/src/locales/translations/*
 echo "Move current branch translations into place for build"
-mv olympus-frontend frontend/src/locales/translations/
+cp -rf olympus-frontend frontend/src/locales/translations/
 echo "Switch to frontend work dir"
 cd frontend
 pwd

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -20,7 +20,7 @@ cd frontend
 pwd
 ls -al
 echo "Prevent build from failing on warnings"
-export process.env.CI = false
+export CI=false
 echo "Build OlympusDAP frontent web site"
 yarn install --frozen-lockfile
 yarn build

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -7,3 +7,5 @@ mv olympus-frontend src/locales/translations/
 cd frontend
 yarn install --frozen-lockfile
 yarn build
+pwd
+ls -al

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
-mkdir frontend
+pwd
+ls -al
+echo "Checkout front end default(develop) branch"
+git clone https://github.com/OlympusDAO/olympus-frontend frontend
+echo "Remove translations from frontend develop checkout"
+rm -rf frontend/src/locales/translations/*
+echo "Move current branch translations into place for build"
+mv olympus-frontend frontend/src/locales/translations/
+echo "Switch to frontend work dir"
 cd frontend
-git clone https://github.com/OlympusDAO/olympus-frontend
-rm -rf src/locales/translations/*
-mv olympus-frontend src/locales/translations/
-cd frontend
+pwd
+ls -al
+echo "Build OlympusDAP frontent web site"
 yarn install --frozen-lockfile
 yarn build
 pwd

--- a/scripts/netlify-preview.sh
+++ b/scripts/netlify-preview.sh
@@ -21,7 +21,7 @@ pwd
 ls -al
 echo "Prevent build from failing on warnings"
 export CI=false
-echo "Build OlympusDAP frontent web site"
+echo "Build OlympusDAP frontent web site "
 yarn install --frozen-lockfile
 yarn build
 pwd


### PR DESCRIPTION
Per discussion with @biwano , this PR provides a way for translators to review their work when they prepare a PR with translation changes.

This PR deploys a preview of the olympus front end to netlify as soon as a new PR is created for the `translators` branch.
